### PR TITLE
Added face limits and named output args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*\__pycache__
+*\pretrained_weights
+*.glb

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Generate a 3D mesh from an image:
 python -m scripts.inference_triposg --image-input assets/example_data/hjswed.png
 ```
 
+Limiting the number of faces and giving a custom name to the output:
+```bash
+python -m scripts.inference_triposg --image-input assets/example_data/hjswed.png --faces 5000 --name "Lowpoly Dino"
+```
+
+
 The required model weights will be automatically downloaded:
 - TripoSG model from [VAST-AI/TripoSG](https://huggingface.co/VAST-AI/TripoSG) → `pretrained_weights/TripoSG`
 - RMBG model from [briaai/RMBG-1.4](https://huggingface.co/briaai/RMBG-1.4) → `pretrained_weights/RMBG-1.4`

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ peft
 jaxtyping
 typeguard
 diso
+pymeshlab # Added for face reduction


### PR DESCRIPTION
The face limit code is the same as can be found in https://huggingface.co/spaces/VAST-AI/TripoSG 's `utils.py`, with a default set to 50,000 faces. Note that this is a limit on the _output_ face count, not the _generated_ faces, so it won't reduce resources needed or speed up generation time, but it should make the model easier to load into other programs. Setting `--faces -1` (or 0) will undo the limit. The `hjswed.png` generation went from 1,339,492 faces and 23MB down to 50,000 faces (obviously) and 880KB with negligible quality loss.

![image](https://github.com/user-attachments/assets/70ca1513-d943-4793-9701-947fa467c03f)
1.4 million faces on the left, 50k faces on the right. No smooth shading or other transforms applied.

Being able to name the outputs just seems like a handy option, especially when comparing different settings.