### PR TITLE
Add Apple Silicon (MPS) support

### DIFF
--- a/scripts/inference_vae.py
+++ b/scripts/inference_vae.py
@@ -18,14 +18,21 @@ def load_surface(data_path, num_pc=204800):
     ind = rng.choice(surface.shape[0], num_pc, replace=False)
     surface = torch.FloatTensor(surface[ind])
     normal = torch.FloatTensor(normal[ind])
-    surface = torch.cat([surface, normal], dim=-1).unsqueeze(0).cuda()
+    surface = torch.cat([surface, normal], dim=-1).unsqueeze(0)
 
     return surface
 
 
 if __name__ == "__main__":
-    device = "cuda"
-    dtype = torch.float16
+    if torch.backends.mps.is_available():
+        device = "mps"
+    elif torch.cuda.is_available():
+        device = "cuda"
+    else:
+        device = "cpu"
+
+    dtype = torch.float16 if device != "cpu" else torch.float32
+
     parser = argparse.ArgumentParser()
     parser.add_argument("--surface-input", type=str, required=True)
     args = parser.parse_args()

--- a/triposg/models/autoencoders/autoencoder_kl_triposg.py
+++ b/triposg/models/autoencoders/autoencoder_kl_triposg.py
@@ -158,7 +158,7 @@ class TripoSGDecoder(nn.Module):
     ):
         logits = model_fn(queries, sample)
         if grad:
-            with torch.autocast(device_type="cuda", dtype=torch.float32):
+            with torch.autocast(device_type=queries.device.type, dtype=torch.float32, enabled=queries.device.type != 'cpu'):
                 if self.grad_type == "numerical":
                     interval = self.grad_interval
                     grad_value = []

--- a/triposg/pipelines/pipeline_triposg_scribble.py
+++ b/triposg/pipelines/pipeline_triposg_scribble.py
@@ -203,7 +203,7 @@ class TripoSGScribblePipeline(DiffusionPipeline, TransformerDiffusionMixin):
         dense_octree_depth: int = 8, 
         hierarchical_octree_depth: int = 9,
         flash_octree_depth: int = 9,
-        use_flash_decoder: bool = True,
+        use_flash_decoder: bool = False, # Defaulting to False due to boundary problems and for MPS compatibility (diso library)
         return_dict: bool = True,
     ):
         self._guidance_scale = guidance_scale
@@ -250,7 +250,7 @@ class TripoSGScribblePipeline(DiffusionPipeline, TransformerDiffusionMixin):
             num_tokens,
             num_channels_latents,
             image_embeds.dtype,
-            device,
+            self.device,
             generator,
             latents,
         )
@@ -327,7 +327,7 @@ class TripoSGScribblePipeline(DiffusionPipeline, TransformerDiffusionMixin):
                 bounds=bounds,
                 octree_depth=flash_octree_depth,
             )
-        meshes = [trimesh.Trimesh(mesh_v_f[0].astype(np.float32), mesh_v_f[1]) for mesh_v_f in output]
+        meshes = [trimesh.Trimesh(mesh_v_f[0].astype(np.float32), mesh_v_f[1]) for mesh_v_f in output if mesh_v_f[0] is not None and mesh_v_f[1] is not None]
         
         # Offload all models
         self.maybe_free_model_hooks()


### PR DESCRIPTION
Issue: #5 

This MR enables the TripoSG project to run on Apple Silicon (macOS) using PyTorch's MPS backend.

**How to Run on macOS (Apple Silicon):**

1. **Enable MPS Fallback (Important):**
Before running any inference script, execute the following in your terminal:
```bash
export PYTORCH_ENABLE_MPS_FALLBACK=1
```
*This is required because some 3D operations used during mesh extraction (e.g., max_pool3d_with_indices) are not yet natively supported on MPS and need to fall back to the CPU.*

2. **Example: Image-to-3D Inference:**
```bash
python3 -m scripts.inference_triposg \
    --image-input assets/example_data/jkghed.png \ 
    --output-path ./output_macos_hierarchical.glb \
    --faces 5000 \
    --no-use-flash-decoder
```
*(Note: --no-use-flash-decoder is recommended for MPS due to potential diso library compatibility and to ensure the CPU fallback path for hierarchical_extract_geometry (which now produces correct results with float32) is used.)*

3. **Example: Scribble-to-3D Inference:**
```bash
python3 -m scripts.inference_triposg_scribble \
    --image-input assets/example_scribble_data/cat_with_wings.png \
    --prompt "a cat with wings" \
    --output-path ./output_macos_scribble.glb
```
