### PR TITLE
Add Examples Docker Support With Webui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,4 @@ pyrightconfig.json
 # End of https://www.toptal.com/developers/gitignore/api/python
 
 pretrained_weights/
+.gradio/*

--- a/examples/docker-wsl-with-webui/Dockerfile
+++ b/examples/docker-wsl-with-webui/Dockerfile
@@ -1,0 +1,48 @@
+FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
+
+# 必要なパッケージのインストール
+RUN apt-get update && apt-get install -y \
+    python3.10 \
+    python3-pip \
+    git \
+    ninja-build \
+    build-essential \
+    gcc-11 \
+    g++-11 \
+    libgl1-mesa-glx \
+    libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+# pythonコマンドのシンボリックリンクを作成
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+# CUDA環境変数の設定
+ENV CUDA_HOME=/usr/local/cuda
+ENV PATH=${CUDA_HOME}/bin:${PATH}
+ENV LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
+ENV TORCH_CUDA_ARCH_LIST="7.5 8.0 8.6"
+ENV FORCE_CUDA=1
+ENV CUDA_ARCH="-arch=sm_75"
+
+# 作業ディレクトリの設定
+WORKDIR /app
+
+# Pythonパッケージのインストール
+COPY requirements.txt .
+RUN pip3 install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cu118
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+# アプリケーションのコピー
+COPY . .
+
+# 環境変数の設定
+ENV PYTHONPATH=/app
+
+# Gradioのポート設定
+ENV GRADIO_SERVER_PORT=7860
+ENV GRADIO_SERVER_NAME=0.0.0.0
+
+EXPOSE 7860
+
+# デフォルトのコマンド
+CMD ["python3", "app.py"]

--- a/examples/docker-wsl-with-webui/Dockerfile
+++ b/examples/docker-wsl-with-webui/Dockerfile
@@ -1,6 +1,6 @@
 FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
 
-# 必要なパッケージのインストール
+# Install necessary packages
 RUN apt-get update && apt-get install -y \
     python3.10 \
     python3-pip \
@@ -13,10 +13,10 @@ RUN apt-get update && apt-get install -y \
     libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
-# pythonコマンドのシンボリックリンクを作成
+# Create symbolic link for python command
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
-# CUDA環境変数の設定
+# Set CUDA environment variables
 ENV CUDA_HOME=/usr/local/cuda
 ENV PATH=${CUDA_HOME}/bin:${PATH}
 ENV LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
@@ -24,25 +24,25 @@ ENV TORCH_CUDA_ARCH_LIST="7.5 8.0 8.6"
 ENV FORCE_CUDA=1
 ENV CUDA_ARCH="-arch=sm_75"
 
-# 作業ディレクトリの設定
+# Set the working directory
 WORKDIR /app
 
-# Pythonパッケージのインストール
+# Install Python packages
 COPY requirements.txt .
 RUN pip3 install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cu118
 RUN pip3 install --no-cache-dir -r requirements.txt
 
-# アプリケーションのコピー
+
+# Copy the application
 COPY . .
 
-# 環境変数の設定
+# Set environment variable
 ENV PYTHONPATH=/app
 
-# Gradioのポート設定
+# Set Gradio server port
 ENV GRADIO_SERVER_PORT=7860
 ENV GRADIO_SERVER_NAME=0.0.0.0
 
 EXPOSE 7860
 
-# デフォルトのコマンド
 CMD ["python3", "app.py"]

--- a/examples/docker-wsl-with-webui/README.md
+++ b/examples/docker-wsl-with-webui/README.md
@@ -1,0 +1,99 @@
+# TripoSG Docker WebUI Setup Guide
+
+This guide explains how to set up and run TripoSG with a web interface using Docker in WSL2 environment.
+
+## Prerequisites
+- Docker installed in WSL2
+- WSL2 installed and configured 
+  - **WSL distro is OFF**
+- NVIDIA Container Toolkit installed
+- Set up `nvidia-smi`
+- CUDA-compatible GPU with at least 8GB VRAM
+
+## Setup Instructions
+
+1. Copy the necessary files to the project root directory:
+
+```bash
+cp Dockerfile docker-compose.yml app.py requirements.txt ../../
+```
+
+2. Build the Docker image in the project root directory:
+
+```bash
+docker-compose build
+docker-compose up -d
+```
+
+The container will be accessible at `http://localhost:7860` once it's running.
+
+## Configuration Details
+
+### Dockerfile Configuration
+
+The Dockerfile includes:
+- CUDA 11.8.0 with cuDNN 8 support
+- Python 3.10
+- Required system libraries for OpenCV
+- PyTorch with CUDA support
+- All necessary Python dependencies
+
+### Environment Variables
+
+The following environment variables are configured:
+- `CUDA_HOME`: CUDA installation path
+- `TORCH_CUDA_ARCH_LIST`: CUDA architecture list
+- `NVIDIA_VISIBLE_DEVICES`: GPU visibility settings
+- `NVIDIA_DRIVER_CAPABILITIES`: GPU capabilities
+- `GRADIO_SERVER_PORT`: WebUI port (7860)
+- `GRADIO_SERVER_NAME`: Server binding address (0.0.0.0)
+
+### Volume Mounts
+
+The following directories are mounted:
+- `./:/app`: Application code
+- `./pretrained_weights:/app/pretrained_weights`: Model weights
+
+## Usage
+
+1. Access the WebUI at `http://localhost:7860` using Gradio
+2. Upload an image or use the scribble interface
+3. Configure generation parameters
+4. Click "Generate" to create 3D models
+
+## Troubleshooting
+
+### Common Issues
+
+1. CUDA Initialization Error
+   - Ensure NVIDIA Container Toolkit is properly installed
+   - Verify GPU is visible in WSL2
+   - Check NVIDIA drivers are up to date
+
+2. OpenCV Dependencies
+   - If you encounter `libGL.so.1` errors, ensure the container is rebuilt with the latest Dockerfile
+
+3. Port Conflicts
+   - If port 7860 is already in use, modify the port mapping in docker-compose.yml
+
+### Debugging Commands
+
+Check GPU availability:
+```bash
+docker exec triposg nvidia-smi
+```
+
+View container logs:
+```bash
+docker-compose logs -f
+```
+
+## Security Notes
+
+- The WebUI is exposed on all interfaces (0.0.0.0)
+- Consider using a reverse proxy for production deployment
+- Keep your NVIDIA drivers and Docker updated for security
+
+## License
+
+This setup is subject to the same license as the TripoSG project. See the main repository for details. 

--- a/examples/docker-wsl-with-webui/README.md
+++ b/examples/docker-wsl-with-webui/README.md
@@ -15,7 +15,7 @@ This guide explains how to set up and run TripoSG with a web interface using Doc
 1. Copy the necessary files to the project root directory:
 
 ```bash
-cp Dockerfile docker-compose.yml app.py requirements.txt ../../
+rsync -aP examples/docker-wsl-with-webui/ ./
 ```
 
 2. Build the Docker image in the project root directory:
@@ -60,40 +60,3 @@ The following directories are mounted:
 2. Upload an image or use the scribble interface
 3. Configure generation parameters
 4. Click "Generate" to create 3D models
-
-## Troubleshooting
-
-### Common Issues
-
-1. CUDA Initialization Error
-   - Ensure NVIDIA Container Toolkit is properly installed
-   - Verify GPU is visible in WSL2
-   - Check NVIDIA drivers are up to date
-
-2. OpenCV Dependencies
-   - If you encounter `libGL.so.1` errors, ensure the container is rebuilt with the latest Dockerfile
-
-3. Port Conflicts
-   - If port 7860 is already in use, modify the port mapping in docker-compose.yml
-
-### Debugging Commands
-
-Check GPU availability:
-```bash
-docker exec triposg nvidia-smi
-```
-
-View container logs:
-```bash
-docker-compose logs -f
-```
-
-## Security Notes
-
-- The WebUI is exposed on all interfaces (0.0.0.0)
-- Consider using a reverse proxy for production deployment
-- Keep your NVIDIA drivers and Docker updated for security
-
-## License
-
-This setup is subject to the same license as the TripoSG project. See the main repository for details. 

--- a/examples/docker-wsl-with-webui/app.py
+++ b/examples/docker-wsl-with-webui/app.py
@@ -1,0 +1,168 @@
+import os
+import gradio as gr
+import torch
+from scripts.inference_triposg import run_triposg
+from scripts.inference_triposg_scribble import run_triposg_scribble
+from triposg.pipelines.pipeline_triposg import TripoSGPipeline
+from triposg.pipelines.pipeline_triposg_scribble import TripoSGScribblePipeline
+from briarmbg import BriaRMBG
+from huggingface_hub import snapshot_download
+import uuid
+
+# デバイスとデータ型の設定
+device = "cuda"
+dtype = torch.float16
+
+# グローバル変数としてモデルを保持
+rmbg_net = None
+pipe = None
+pipe_scribble = None
+
+# 事前学習済みモデルのダウンロード
+def download_models():
+    triposg_weights_dir = "pretrained_weights/TripoSG"
+    triposg_scribble_weights_dir = "pretrained_weights/TripoSG-scribble"
+    rmbg_weights_dir = "pretrained_weights/RMBG-1.4"
+    
+    if not os.path.exists(triposg_weights_dir):
+        snapshot_download(repo_id="VAST-AI/TripoSG", local_dir=triposg_weights_dir)
+    if not os.path.exists(triposg_scribble_weights_dir):
+        snapshot_download(repo_id="VAST-AI/TripoSG-scribble", local_dir=triposg_scribble_weights_dir)
+    if not os.path.exists(rmbg_weights_dir):
+        snapshot_download(repo_id="briaai/RMBG-1.4", local_dir=rmbg_weights_dir)
+
+# モデルの初期化
+def init_models():
+    global rmbg_net, pipe, pipe_scribble
+    
+    if rmbg_net is None:
+        # RMBGモデルの初期化
+        rmbg_net = BriaRMBG.from_pretrained("pretrained_weights/RMBG-1.4").to(device)
+        rmbg_net.eval()
+
+    if pipe is None:
+        # TripoSGモデルの初期化
+        pipe = TripoSGPipeline.from_pretrained("pretrained_weights/TripoSG").to(device, dtype)
+    
+    if pipe_scribble is None:
+        # TripoSG-scribbleモデルの初期化
+        pipe_scribble = TripoSGScribblePipeline.from_pretrained("pretrained_weights/TripoSG-scribble").to(device, dtype)
+    
+    return rmbg_net, pipe, pipe_scribble
+
+# 画像から3Dモデルを生成
+def generate_3d_from_image(image, seed, num_inference_steps, guidance_scale, faces, session_id=None):
+    global rmbg_net, pipe
+    if rmbg_net is None or pipe is None:
+        rmbg_net, pipe, _ = init_models()
+
+    sid = str(uuid.uuid4()) if session_id is None else session_id
+
+    # image(PIL.Image) -> image_path
+    image_path = os.path.join(os.getcwd(), f"input_{sid}.png")
+    image.save(image_path)
+    
+    mesh = run_triposg(
+        pipe,
+        image_input=image_path,
+        rmbg_net=rmbg_net,
+        seed=seed,
+        num_inference_steps=num_inference_steps,
+        guidance_scale=guidance_scale,
+        faces=faces,
+    )
+    
+    output_path = os.path.join(os.getcwd(), f"output_{sid}.glb")
+    mesh.export(output_path)
+    return output_path
+
+# スケッチとプロンプトから3Dモデルを生成
+def generate_3d_from_scribble(image, prompt, seed, num_inference_steps, scribble_conf, prompt_conf, session_id=None):
+    global pipe_scribble
+    if pipe_scribble is None:
+        _, _, pipe_scribble = init_models()
+
+    sid = str(uuid.uuid4()) if session_id is None else session_id
+    image_path = os.path.join(os.getcwd(), f"input_{sid}.png")
+    image.save(image_path)
+    
+    mesh = run_triposg_scribble(
+        pipe_scribble,
+        image_input=image_path,
+        prompt=prompt,
+        seed=seed,
+        num_inference_steps=num_inference_steps,
+        scribble_confidence=scribble_conf,
+        prompt_confidence=prompt_conf,
+    )
+    
+    output_path = os.path.join(os.getcwd(), "output_scribble.glb")
+    mesh.export(output_path)
+    return output_path
+
+# Gradioインターフェースの作成
+def create_interface():
+    with gr.Blocks(title="TripoSG WebUI") as demo:
+        gr.Markdown("# TripoSG WebUI")
+        
+        with gr.Tabs():
+            with gr.TabItem("Image to 3D"):
+                with gr.Row():
+                    with gr.Column():
+                        image_input = gr.Image(type="pil", label="Input Image")
+                        seed = gr.Slider(minimum=0, maximum=1000, value=42, step=1, label="Seed")
+                        num_inference_steps = gr.Slider(minimum=1, maximum=100, value=50, step=1, label="Inference Steps")
+                        guidance_scale = gr.Slider(minimum=1.0, maximum=20.0, value=7.0, step=0.1, label="Guidance Scale")
+                        faces = gr.Slider(minimum=-1, maximum=10000, value=-1, step=100, label="Number of Faces (-1 for no reduction)")
+                        generate_btn = gr.Button("Generate 3D Model")
+                    
+                    with gr.Column():
+                        output_model = gr.Model3D(label="Generated 3D Model")
+                
+                generate_btn.click(
+                    fn=generate_3d_from_image,
+                    inputs=[image_input, seed, num_inference_steps, guidance_scale, faces],
+                    outputs=output_model
+                )
+            
+            with gr.TabItem("Scribble to 3D"):
+                with gr.Row():
+                    with gr.Column():
+                        scribble_input = gr.Image(type="pil", label="Input Scribble")
+                        prompt = gr.Textbox(label="Prompt")
+                        scribble_seed = gr.Slider(minimum=0, maximum=1000, value=42, step=1, label="Seed")
+                        scribble_steps = gr.Slider(minimum=1, maximum=100, value=16, step=1, label="Inference Steps")
+                        scribble_conf = gr.Slider(minimum=0.1, maximum=1.0, value=0.4, step=0.1, label="Scribble Confidence")
+                        prompt_conf = gr.Slider(minimum=0.1, maximum=1.0, value=1.0, step=0.1, label="Prompt Confidence")
+                        generate_scribble_btn = gr.Button("Generate 3D Model")
+                    
+                    with gr.Column():
+                        scribble_output = gr.Model3D(label="Generated 3D Model")
+                
+                generate_scribble_btn.click(
+                    fn=generate_3d_from_scribble,
+                    inputs=[scribble_input, prompt, scribble_seed, scribble_steps, scribble_conf, prompt_conf],
+                    outputs=scribble_output
+                )
+        
+        gr.Markdown("""
+        ## Usage Instructions
+        1. **Image to 3D**: Upload an image and adjust parameters to generate a 3D model
+        2. **Scribble to 3D**: Upload a scribble image, provide a prompt, and adjust parameters to generate a 3D model
+        
+        Note: The first run will download the model weights, which may take some time.
+        """)
+    
+    return demo
+
+if __name__ == "__main__":
+    # モデルのダウンロード
+    download_models()
+    
+    # Gradioインターフェースの作成と起動
+    demo = create_interface()
+    demo.launch(
+        server_name="0.0.0.0",
+        server_port=7860,
+        share=True,
+    ) 

--- a/examples/docker-wsl-with-webui/docker-compose.yml
+++ b/examples/docker-wsl-with-webui/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  triposg:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: triposg:latest
+    container_name: triposg
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    ports:
+      - "7860:7860"
+    volumes:
+      - ./:/app
+      - ./pretrained_weights:/app/pretrained_weights
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+      - GRADIO_SERVER_NAME=0.0.0.0
+      - GRADIO_SERVER_PORT=7860
+      - GRADIO_RELOAD=True
+    command: python app.py

--- a/examples/docker-wsl-with-webui/requirements.txt
+++ b/examples/docker-wsl-with-webui/requirements.txt
@@ -1,0 +1,15 @@
+diffusers
+transformers
+einops
+huggingface_hub
+opencv-python
+trimesh
+omegaconf
+scikit-image
+numpy==1.22.3
+peft
+jaxtyping
+typeguard
+diso
+pymeshlab
+gradio>=5.0.0


### PR DESCRIPTION
## Summary
This PR adds a Docker-based WebUI setup for TripoSG, making it easier to run the application in a containerized environment with CUDA support. The setup includes:

- Dockerfile with CUDA 11.8.0 and cuDNN 8 support
- docker-compose.yml for easy deployment
- Gradio-based WebUI implementation (app.py)
- Comprehensive setup guide in README.md

**NOTES**: require docker desktop settings -> `WSL distro is OFF`

## Setup Instructions
1. Copy the Docker setup files to the project root:
```bash
rsync -aP examples/docker-wsl-with-webui/ ./
```
2. Build and run the container:
```bash
docker-compose build
docker-compose up -d
```
3. Access the WebUI at `http://localhost:7860`

## WebUI (Gradio)
separating tab Image / Scribble
available pushing on the `Generate 3D Model` Button
### Image to 3D
![image](https://github.com/user-attachments/assets/63fc36b3-9d32-4104-bb03-c2e0e291a2da)

### Scribble to 3D
![image](https://github.com/user-attachments/assets/0306fed0-0f18-405d-ba8e-b8d6d49664d7)
